### PR TITLE
Modify primary key for date dimensions

### DIFF
--- a/migrate/model_migrate.py
+++ b/migrate/model_migrate.py
@@ -81,7 +81,7 @@ def transform_dataset(source):
                     'source': norm_name + '_yearmonth'
                 } 
             }
-            dim['primaryKey'] = 'label'
+            dim['primaryKey'] = ['year','month','day']
             dim['dimensionType'] = 'datetime'
         if src.get('type') == 'attribute':
             dim['attributes'] = {


### PR DESCRIPTION
Hey @danfowler , I think that for date fields we'd want the primary keys to consist of the actual values for (year,month,day), as it would make it easier to use on queries (e.g. cut on year=X).

wdyt?
